### PR TITLE
Support using FP32 SD checkpoints

### DIFF
--- a/Axodox.MachineLearning.Shared/MachineLearning/StableDiffustionInferer.h
+++ b/Axodox.MachineLearning.Shared/MachineLearning/StableDiffustionInferer.h
@@ -39,6 +39,7 @@ namespace Axodox::MachineLearning
   private:
     OnnxEnvironment& _environment;
     Ort::Session _session;
+    bool _isHalfModel;
 
     static Tensor GenerateLatentSample(StableDiffusionContext& context);
     static Tensor PrepareLatentSample(StableDiffusionContext& context, const Tensor& latents, float initialSigma);

--- a/Axodox.MachineLearning.Shared/MachineLearning/Tensor.cpp
+++ b/Axodox.MachineLearning.Shared/MachineLearning/Tensor.cpp
@@ -150,6 +150,7 @@ namespace Axodox::MachineLearning
 
   Tensor Tensor::ToSingle() const
   {
+    if (Type == TensorType::Single) return *this;
     if (Type != TensorType::Half) throw bad_cast();
 
     auto size = Size();
@@ -162,6 +163,7 @@ namespace Axodox::MachineLearning
 
   Tensor Tensor::ToHalf() const
   {
+    if (Type == TensorType::Half) return *this;
     if (Type != TensorType::Single) throw bad_cast();
 
     auto size = Size();

--- a/Axodox.MachineLearning.Shared/MachineLearning/VaeDecoder.h
+++ b/Axodox.MachineLearning.Shared/MachineLearning/VaeDecoder.h
@@ -14,5 +14,6 @@ namespace Axodox::MachineLearning
   private:
     OnnxEnvironment& _environment;
     Ort::Session _session;
+    bool _isHalfModel;
   };
 }


### PR DESCRIPTION
Check the input type the session needs before unconditionally converting to fp16.
Make ToSingle and ToHalf methods no-ops if the Tensor is already in the right format