### PR TITLE
Display ONNX logging output

### DIFF
--- a/Axodox.MachineLearning.Shared/MachineLearning/OnnxEnvironment.h
+++ b/Axodox.MachineLearning.Shared/MachineLearning/OnnxEnvironment.h
@@ -21,5 +21,11 @@ namespace Axodox::MachineLearning
     std::filesystem::path _rootPath;
     Ort::Env _environment;
     Ort::MemoryInfo _memoryInfo;
+    void OrtLoggingFunction(OrtLoggingLevel severity, const char* category, const char* logid, const char* code_location, const char* message);
+    static void ORT_API_CALL OrtLoggingFunctionCallback(void* param, OrtLoggingLevel severity, const char* category, const char* logid, const char* code_location, const char* message);
+#ifdef PLATFORM_WINDOWS
+    winrt::Windows::Foundation::Diagnostics::LoggingChannel _logChannel = nullptr;
+    static winrt::Windows::Foundation::Diagnostics::FileLoggingSession _loggingSession;
+#endif
   };
 }

--- a/Axodox.MachineLearning.Shared/includes.h
+++ b/Axodox.MachineLearning.Shared/includes.h
@@ -3,6 +3,7 @@
 
 #ifdef PLATFORM_WINDOWS
 #include <winrt/windows.foundation.h>
+#include <winrt/windows.foundation.diagnostics.h>
 #include <winrt/windows.web.http.h>
 #include <winrt/windows.web.http.filters.h>
 #include <winrt/windows.web.http.headers.h>


### PR DESCRIPTION
-Connect ONNX logging output to WinRT FileLoggingSession and also OutputDebugString
-Change default level from ORT_LOGGING_LEVEL_ERROR to ORT_LOGGING_LEVEL_WARNING

I'm not sure if this was going somewhere else before and this change is redundant but I couldn't find it. If so I'll close this.